### PR TITLE
fix bug in custome styles

### DIFF
--- a/app/src/main/res/layout/fragment_draggable_tv_show.xml
+++ b/app/src/main/res/layout/fragment_draggable_tv_show.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/AppTheme.RootView">
+    style="@style/CustomeStyle.RootView">
 
   <!-- ProgressBar -->
 
   <ProgressBar
       android:id="@+id/pb_loading"
-      style="@style/AppTheme.ProgressBar"/>
+      style="@style/CustomeStyle.ProgressBar"/>
 
   <!-- DraggableView -->
 
@@ -29,14 +29,14 @@
     <ListView
         android:id="@+id/lv_chapters"
         android:layout_below="@+id/iv_fan_art"
-        style="@style/AppTheme.ListView"/>
+        style="@style/CustomeStyle.ListView"/>
 
     <!-- TvShow Fan Art -->
 
     <ImageView
         android:id="@+id/iv_fan_art"
         android:layout_alignParentTop="true"
-        style="@style/AppTheme.Image.TvShowFranArt"/>
+        style="@style/CustomeStyle.Image.TvShowFranArt"/>
 
   </com.github.pedrovgs.DraggableView>
 

--- a/app/src/main/res/layout/fragment_tv_show.xml
+++ b/app/src/main/res/layout/fragment_tv_show.xml
@@ -5,20 +5,20 @@
     android:layout_height="match_parent">
 
   <LinearLayout
-      style="@style/AppTheme.RootView.Vertical">
+      style="@style/CustomeStyle.RootView.Vertical">
 
     <!-- TvShow Fan Art -->
 
     <ImageView
         android:id="@+id/iv_fan_art"
-        style="@style/AppTheme.Image.TvShowFranArt"/>
+        style="@style/CustomeStyle.Image.TvShowFranArt"/>
 
     <!-- ListView Chapters -->
 
     <ListView
         android:id="@+id/lv_chapters"
         android:visibility="gone"
-        style="@style/AppTheme.ListView"/>
+        style="@style/CustomeStyle.ListView"/>
 
   </LinearLayout>
 
@@ -26,13 +26,13 @@
 
   <ProgressBar
       android:id="@+id/pb_loading"
-      style="@style/AppTheme.ProgressBar"/>
+      style="@style/CustomeStyle.ProgressBar"/>
 
   <!-- EmptyCase -->
 
   <ImageView
       android:id="@+id/v_empty_case"
-      style="@style/AppTheme.EmptyCase"/>
+      style="@style/CustomeStyle.EmptyCase"/>
 
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_tv_shows.xml
+++ b/app/src/main/res/layout/fragment_tv_shows.xml
@@ -2,24 +2,24 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="com.github.pedrovgs.effectiveandroidui.ui.activity.MainActivity$PlaceholderFragment"
-    style="@style/AppTheme.RootView">
+    style="@style/CustomeStyle.RootView">
 
   <!-- ProgressBar -->
 
   <ProgressBar
       android:id="@+id/pb_loading"
-      style="@style/AppTheme.ProgressBar"/>
+      style="@style/CustomeStyle.ProgressBar"/>
 
   <!-- EmptyCase -->
 
   <ImageView
       android:id="@+id/v_empty_case"
-      style="@style/AppTheme.EmptyCase"/>
+      style="@style/CustomeStyle.EmptyCase"/>
 
   <!-- GridView -->
 
   <GridView
       android:id="@+id/gv_tv_shows"
-      style="@style/AppTheme.GridView"/>
+      style="@style/CustomeStyle.GridView"/>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/header_tv_show_chapters.xml
+++ b/app/src/main/res/layout/header_tv_show_chapters.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView
-    style="@style/AppTheme.TextListViewHeader"/>
+    style="@style/CustomeStyle.TextListViewHeader"/>

--- a/app/src/main/res/layout/row_tv_show.xml
+++ b/app/src/main/res/layout/row_tv_show.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/v_row_container"
-    style="@style/AppTheme.TvShow">
+    style="@style/CustomeStyle.TvShow">
 
   <ImageView
       android:id="@+id/iv_thumbnail"
-      style="@style/AppTheme.Image.TvShow"
+      style="@style/CustomeStyle.Image.TvShow"
       android:layout_alignParentTop="true"/>
 
   <TextView
       android:id="@+id/tv_title"
       android:layout_below="@+id/iv_thumbnail"
-      style="@style/AppTheme.Title.TvShow"/>
+      style="@style/CustomeStyle.Title.TvShow"/>
 
   <TextView
       android:id="@+id/tv_seasons_counter"
       android:layout_below="@+id/tv_title"
-      style="@style/AppTheme.Subtitle.TvShow"/>
+      style="@style/CustomeStyle.Subtitle.TvShow"/>
 
 </RelativeLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,35 +6,37 @@
   <style name="AppTheme" parent="Theme.AppCompat.Light">
     <item name="android:windowBackground">@color/main_color</item>
   </style>
+  
+  <style name="CustomeStyle" />ss
 
-  <style name="AppTheme.RootView">
+  <style name="CustomeStyle.RootView">
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">match_parent</item>
   </style>
 
-  <style name="AppTheme.RootView.Vertical">
+  <style name="CustomeStyle.RootView.Vertical">
     <item name="android:orientation">vertical</item>
   </style>
 
-  <style name="AppTheme.Image">
+  <style name="CustomeStyle.Image">
     <item name="android:scaleType">centerCrop</item>
     <item name="android:background">@color/main_color</item>
   </style>
 
-  <style name="AppTheme.Title">
+  <style name="CustomeStyle.Title">
     <item name="android:textStyle">bold</item>
     <item name="android:textColor">@color/fourth_color</item>
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">wrap_content</item>
   </style>
 
-  <style name="AppTheme.Subtitle">
+  <style name="CustomeStyle.Subtitle">
     <item name="android:textColor">@color/third_color</item>
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">wrap_content</item>
   </style>
 
-  <style name="AppTheme.GridView">
+  <style name="CustomeStyle.GridView">
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">match_parent</item>
     <item name="android:numColumns">@integer/tv_shows_grid_view_num_colums</item>
@@ -42,14 +44,14 @@
     <item name="android:horizontalSpacing">@dimen/main_margin</item>
   </style>
 
-  <style name="AppTheme.ListView">
+  <style name="CustomeStyle.ListView">
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">match_parent</item>
     <item name="android:dividerHeight">@dimen/divider_height</item>
     <item name="android:divider">@color/sixth_color</item>
   </style>
 
-  <style name="AppTheme.ProgressBar">
+  <style name="CustomeStyle.ProgressBar">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_centerVertical">true</item>
@@ -58,7 +60,7 @@
     <item name="android:visibility">gone</item>
   </style>
 
-  <style name="AppTheme.EmptyCase">
+  <style name="CustomeStyle.EmptyCase">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_centerVertical">true</item>
@@ -69,36 +71,36 @@
     <item name="android:src">@drawable/empty_case</item>
   </style>
 
-  <style name="AppTheme.TvShow">
+  <style name="CustomeStyle.TvShow">
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:background">@color/secondary_color</item>
   </style>
 
-  <style name="AppTheme.Image.TvShow">
+  <style name="CustomeStyle.Image.TvShow">
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">@dimen/poster_height</item>
   </style>
 
-  <style name="AppTheme.Title.TvShow">
+  <style name="CustomeStyle.Title.TvShow">
     <item name="android:ellipsize">end</item>
     <item name="android:singleLine">true</item>
     <item name="android:layout_marginLeft">@dimen/secondary_margin</item>
   </style>
 
-  <style name="AppTheme.Subtitle.TvShow">
+  <style name="CustomeStyle.Subtitle.TvShow">
     <item name="android:ellipsize">end</item>
     <item name="android:singleLine">true</item>
     <item name="android:layout_marginLeft">@dimen/secondary_margin</item>
     <item name="android:paddingBottom">@dimen/main_margin</item>
   </style>
 
-  <style name="AppTheme.Image.TvShowFranArt">
+  <style name="CustomeStyle.Image.TvShowFranArt">
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">@dimen/fan_art_height</item>
   </style>
 
-  <style name="AppTheme.TextListViewHeader">
+  <style name="CustomeStyle.TextListViewHeader">
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_width">match_parent</item>
     <item name="android:background">@color/secondary_color</item>


### PR DESCRIPTION
this PR will fix bug for [#16](https://github.com/pedrovgs/EffectiveAndroidUI/issues/16) && [#17](https://github.com/pedrovgs/EffectiveAndroidUI/issues/17)

according to [Styles and Themes ](http://developer.android.com/guide/topics/ui/themes.html#inheritance) 
>Note: This technique for inheritance by chaining together names only works for styles defined by your own resources. You can't inherit Android built-in styles this way. To reference a built-in style, such as TextAppearance, you must use the parent attribute.


hoping this PR will help you to fix these bugs,maybe have a better solution.FYI.
